### PR TITLE
Improve .gitignore and a word on scroll events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-./build/*
 ./mangoviewer
 *_style.h
+build
+mangoviewer


### PR DESCRIPTION
Hello,

I've tried checking why `event->scroll.direction` always emit `4` (scroll down) and why `event->scroll.delta_y` always emit `0` and due to my lack of experience with GTK+, I could not find anything (even messing around and such).

Here are screenshots of semi-interesting warnings, although I doubt it would mean much.

![1](https://user-images.githubusercontent.com/8390674/49459967-451a5280-f7be-11e8-9fb6-6917a8ad82a6.png)
![2](https://user-images.githubusercontent.com/8390674/49459975-48154300-f7be-11e8-9557-a0233db789ff.png)

